### PR TITLE
BlockTheSpot V2.0

### DIFF
--- a/BlockTheSpot/BlockTheSpot.csproj
+++ b/BlockTheSpot/BlockTheSpot.csproj
@@ -8,15 +8,16 @@
     <OutputType>WinExe</OutputType>
     <RootNamespace>BlockTheSpot</RootNamespace>
     <AssemblyName>BlockTheSpot</AssemblyName>
-    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <Deterministic>true</Deterministic>
     <IsWebBootstrapper>false</IsWebBootstrapper>
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
+    <TargetFrameworkProfile />
     <PublishUrl>C:\Users\PVita\Desktop\</PublishUrl>
-    <Install>true</Install>
+    <Install>false</Install>
     <InstallFrom>Disk</InstallFrom>
     <UpdateEnabled>false</UpdateEnabled>
     <UpdateMode>Foreground</UpdateMode>
@@ -25,12 +26,14 @@
     <UpdatePeriodically>false</UpdatePeriodically>
     <UpdateRequired>false</UpdateRequired>
     <MapFileExtensions>false</MapFileExtensions>
-    <ApplicationRevision>54</ApplicationRevision>
-    <ApplicationVersion>1.0.0.%2a</ApplicationVersion>
+    <SupportUrl>https://github.com/bitasuperactive/BlockTheSpot-C-Sharp/</SupportUrl>
+    <ProductName>BlockTheSpot-C-Sharp</ProductName>
+    <PublisherName>bitasuperactive</PublisherName>
+    <ApplicationRevision>29</ApplicationRevision>
+    <ApplicationVersion>2.0.0.%2a</ApplicationVersion>
     <UseApplicationTrust>false</UseApplicationTrust>
     <PublishWizardCompleted>true</PublishWizardCompleted>
     <BootstrapperEnabled>false</BootstrapperEnabled>
-    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -60,7 +63,7 @@
     <ManifestKeyFile>BlockTheSpot_TemporaryKey.pfx</ManifestKeyFile>
   </PropertyGroup>
   <PropertyGroup>
-    <GenerateManifests>false</GenerateManifests>
+    <GenerateManifests>true</GenerateManifests>
   </PropertyGroup>
   <PropertyGroup>
     <TargetZone>LocalIntranet</TargetZone>
@@ -80,6 +83,8 @@
     <Reference Include="Microsoft.VisualBasic" />
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.DirectoryServices.AccountManagement" />
+    <Reference Include="System.IO.Compression.FileSystem" />
     <Reference Include="System.Management" />
     <Reference Include="System.Management.Automation, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.PowerShell.5.ReferenceAssemblies.1.1.0\lib\net4\System.Management.Automation.dll</HintPath>
@@ -93,6 +98,9 @@
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xml" />
+    <Reference Include="Windows">
+      <HintPath>..\..\..\..\..\..\Program Files (x86)\Windows Kits\10\UnionMetadata\10.0.19041.0\Windows.winmd</HintPath>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Form1.cs">
@@ -149,6 +157,9 @@
     <None Include="Resources\DoneImage.png" />
     <None Include="Resources\AddsOnImage.png" />
     <None Include="Resources\AddsOffImage.png" />
+  </ItemGroup>
+  <ItemGroup>
+    <WCFMetadata Include="Connected Services\" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/BlockTheSpot/Form1.Designer.cs
+++ b/BlockTheSpot/Form1.Designer.cs
@@ -41,9 +41,10 @@
             // 
             this.PatchButton.Cursor = System.Windows.Forms.Cursors.Hand;
             this.PatchButton.Font = new System.Drawing.Font("Calibri", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.PatchButton.Location = new System.Drawing.Point(12, 59);
+            this.PatchButton.Location = new System.Drawing.Point(16, 73);
+            this.PatchButton.Margin = new System.Windows.Forms.Padding(4);
             this.PatchButton.Name = "PatchButton";
-            this.PatchButton.Size = new System.Drawing.Size(192, 54);
+            this.PatchButton.Size = new System.Drawing.Size(256, 66);
             this.PatchButton.TabIndex = 12;
             this.PatchButton.Text = "Bloquear anuncios";
             this.PatchButton.UseVisualStyleBackColor = true;
@@ -53,9 +54,10 @@
             // 
             this.ResetButton.Cursor = System.Windows.Forms.Cursors.Hand;
             this.ResetButton.Font = new System.Drawing.Font("Calibri", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.ResetButton.Location = new System.Drawing.Point(12, 119);
+            this.ResetButton.Location = new System.Drawing.Point(16, 146);
+            this.ResetButton.Margin = new System.Windows.Forms.Padding(4);
             this.ResetButton.Name = "ResetButton";
-            this.ResetButton.Size = new System.Drawing.Size(192, 54);
+            this.ResetButton.Size = new System.Drawing.Size(256, 66);
             this.ResetButton.TabIndex = 13;
             this.ResetButton.Text = "Restablecer Spotify";
             this.ResetButton.UseVisualStyleBackColor = true;
@@ -68,9 +70,10 @@
             this.SpotifyPictureBox.ErrorImage = null;
             this.SpotifyPictureBox.Image = global::BlockTheSpot.Properties.Resources.AddsOnImage;
             this.SpotifyPictureBox.InitialImage = null;
-            this.SpotifyPictureBox.Location = new System.Drawing.Point(5, 5);
+            this.SpotifyPictureBox.Location = new System.Drawing.Point(7, 6);
+            this.SpotifyPictureBox.Margin = new System.Windows.Forms.Padding(4);
             this.SpotifyPictureBox.Name = "SpotifyPictureBox";
-            this.SpotifyPictureBox.Size = new System.Drawing.Size(199, 48);
+            this.SpotifyPictureBox.Size = new System.Drawing.Size(265, 59);
             this.SpotifyPictureBox.SizeMode = System.Windows.Forms.PictureBoxSizeMode.Zoom;
             this.SpotifyPictureBox.TabIndex = 7;
             this.SpotifyPictureBox.TabStop = false;
@@ -81,9 +84,10 @@
             this.WorkingPictureBox.ErrorImage = null;
             this.WorkingPictureBox.Image = global::BlockTheSpot.Properties.Resources.WorkingImage;
             this.WorkingPictureBox.InitialImage = null;
-            this.WorkingPictureBox.Location = new System.Drawing.Point(12, 59);
+            this.WorkingPictureBox.Location = new System.Drawing.Point(16, 73);
+            this.WorkingPictureBox.Margin = new System.Windows.Forms.Padding(4);
             this.WorkingPictureBox.Name = "WorkingPictureBox";
-            this.WorkingPictureBox.Size = new System.Drawing.Size(192, 116);
+            this.WorkingPictureBox.Size = new System.Drawing.Size(256, 143);
             this.WorkingPictureBox.SizeMode = System.Windows.Forms.PictureBoxSizeMode.Zoom;
             this.WorkingPictureBox.TabIndex = 12;
             this.WorkingPictureBox.TabStop = false;
@@ -91,10 +95,10 @@
             // 
             // BlockTheSpot
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 16F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(25)))), ((int)(((byte)(230)))), ((int)(((byte)(140)))));
-            this.ClientSize = new System.Drawing.Size(218, 187);
+            this.ClientSize = new System.Drawing.Size(291, 230);
             this.Controls.Add(this.ResetButton);
             this.Controls.Add(this.PatchButton);
             this.Controls.Add(this.SpotifyPictureBox);
@@ -102,12 +106,14 @@
             this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedDialog;
             this.HelpButton = true;
             this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
+            this.Margin = new System.Windows.Forms.Padding(4);
             this.MaximizeBox = false;
             this.MinimizeBox = false;
             this.Name = "BlockTheSpot";
             this.ShowIcon = false;
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen;
             this.Text = "BlockTheSpot";
+            this.TopMost = true;
             this.HelpButtonClicked += new System.ComponentModel.CancelEventHandler(this.BlockTheSpot_HelpButtonClicked);
             this.FormClosing += new System.Windows.Forms.FormClosingEventHandler(this.BlockTheSpot_FormClosing);
             this.Load += new System.EventHandler(this.BlockTheSpot_Load);

--- a/BlockTheSpot/Form1.cs
+++ b/BlockTheSpot/Form1.cs
@@ -2,50 +2,45 @@
 using System.Linq;
 using System.Net;
 using System.Security.Principal;
-using System.Threading.Tasks;
 using System.Windows.Forms;
 using System.IO;
 using System.Diagnostics;
 using System.Security.AccessControl;
-using System.Management.Automation;
 using System.Threading;
-using Microsoft.Win32;
+using System.Collections.Generic;
 
 namespace BlockTheSpot
 {
     public partial class BlockTheSpot : Form
     {
-        private static string SpotifyDir { get; set; } = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData) + "\\Spotify";
-        private static string UpdateFolderDir { get; set; } = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData) + "\\Spotify\\Update";
+        private static string SpotifyDir { get; } = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData) + "\\Spotify";
+        private static string SpotifyLocalDir { get; } = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData) + "\\Spotify";
+        private static Uri SpotifyUri { get; } = new Uri("https://upgrade.scdn.co/upgrade/client/win32-x86/spotify_installer-1.1.89.862.g94554d24-13.exe");
+        private static Uri ChromeElfUri { get; } = new Uri("https://github.com/mrpond/BlockTheSpot/releases/latest/download/chrome_elf.zip");
+
 
         public BlockTheSpot()
         {
+            CheckIfAlreadyLaunched();
             InitializeComponent();
         }
 
+
+        private void CheckIfAlreadyLaunched()
+        {
+            bool alreadyLaunched = Process.GetProcesses().Count(p => p.ProcessName.Equals(Process.GetCurrentProcess().ProcessName)) > 1;
+
+            if (alreadyLaunched)
+            {
+                MessageBox.Show("Ya existe una instancia activa de BlockTheSpot.", "BlockTheSpot", MessageBoxButtons.OK, MessageBoxIcon.Exclamation);
+                Application.Exit();
+            }
+        }
+        //
+        // Comprueba si el parcheado ya ha sido realizado y, si Spotify versión de escritorio esta instalado.
         private void BlockTheSpot_Load(object sender, EventArgs e)
         {
-            CheckRequirements();
-        }
-
-        private void CheckRequirements()
-        {
-            if (Process.GetProcesses().Count(process => process.ProcessName == Process.GetCurrentProcess().ProcessName) > 1)
-            {
-                MessageBox.Show("BlockTheSpot no responde.", "KCI", MessageBoxButtons.OK, MessageBoxIcon.Exclamation);
-                Application.Exit();
-            }
-            else if (Registry.LocalMachine.OpenSubKey(@"SOFTWARE\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\PackageRepository\Extensions\windows.protocol\spotify") != null)
-            {
-                MessageBox.Show(this, "La versión Microsoft Store de Spotify no es compatible con esta aplicación." + Environment.NewLine + "Desinstala Spotify y reinicia BlockTheSpot.", "BlockTheSpot", MessageBoxButtons.OK, MessageBoxIcon.Exclamation);
-                Application.Exit();
-            }
-            else if (new WindowsPrincipal(WindowsIdentity.GetCurrent()).IsInRole(WindowsBuiltInRole.Administrator))
-            {
-                MessageBox.Show("Por favor inicia BlockTheSpot sin privilegios de Administrador.", "KCI", MessageBoxButtons.OK, MessageBoxIcon.Exclamation);
-                Application.Exit();
-            }
-            else if (!DowngradeRequired() && File.Exists($@"{SpotifyDir}\netutils.dll"))
+            if (!DowngradeRequired() && File.Exists($@"{SpotifyDir}\chrome_elf_bak.dll") && File.Exists($@"{SpotifyDir}\config.ini"))
             {
                 SpotifyPictureBox.Image = Properties.Resources.AddsOffImage;
                 PatchButton.Enabled = false;
@@ -53,124 +48,184 @@ namespace BlockTheSpot
             else
                 ResetButton.Enabled = false;
 
-            if (!File.Exists($@"{SpotifyDir}\Spotify.exe")) PatchButton.Text = "Instalar Spotify y" + Environment.NewLine + "Bloquear anuncios";
+            if (!File.Exists($@"{SpotifyDir}\Spotify.exe"))
+                PatchButton.Text = "Instalar Spotify y\n" + "Bloquear anuncios";
         }
-
+        //
+        // Comprueba si la versión actual de Spotify es superior a la compatible (1.1.89.862).
+        // Si Spotify no está instalado, devuelve <true>.
         private bool DowngradeRequired()
         {
-            if (File.Exists($@"{SpotifyDir}\Spotify.exe"))
-            {
-                Version actualSpotifyVersion = new Version(FileVersionInfo.GetVersionInfo(SpotifyDir + "\\Spotify.exe").FileVersion.ToString());
-                if (actualSpotifyVersion.CompareTo(new Version("1.1.4.197")) > 0) return true; else return false;
-            }
-            else return true;
-        }
+            bool spotifyIsInstalled = File.Exists($@"{SpotifyDir}\Spotify.exe");
 
-        #region Buttons
-        private void PatchButton_Click(object sender, EventArgs e) => PatchButtonMethod();
-        private void ResetButton_Click(object sender, EventArgs e) => ResetButtonMethod();
-        private void BlockTheSpot_HelpButtonClicked(object sender, System.ComponentModel.CancelEventArgs e) => Process.Start("https://github.com/bitasuperactive/BlockTheSpot-OneClick");
+            Version actualVer = (!spotifyIsInstalled) ? null :
+                new Version(FileVersionInfo.GetVersionInfo(SpotifyDir + "\\Spotify.exe").FileVersion);
+
+            return (actualVer == null || actualVer.CompareTo(new Version("1.1.89.862")) > 0) ? true : false;
+        }
 
         private void PatchButtonMethod()
         {
-            this.Cursor = Cursors.Default;
+            Cursor = Cursors.Default;
             WorkingPictureBox.BringToFront();
             WorkingPictureBox.Visible = true;
 
-            TerminateSpotify();
-
             try
             {
-                SpotifyDowngrade();
-                InjectNatutils();
+                TerminateSpotify();
+                WinStorePackageRemoval();
+                DowngradeClient();
+                Patch();
                 DisableAutoUpdate();
-                PowerShell.Create().AddScript(@"$ws = New-Object -ComObject WScript.Shell; $s = $ws.CreateShortcut($env:USERPROFILE + '\Desktop\Spotify.lnk'); $S.TargetPath = $env:APPDATA + '\Spotify\Spotify.exe'; $S.Save()").Invoke();
-                Finish(true, "¡Todo listo! Gracias por utilizar BlockTheSpot.");
+
+                // Si existe un acceso directo a Spotify en el escritorio, eliminalo.
+                if (File.Exists($@"{Environment.GetFolderPath(Environment.SpecialFolder.Desktop)}\Spotify.lnk"))
+                    File.Delete($@"{Environment.GetFolderPath(Environment.SpecialFolder.Desktop)}\Spotify.lnk");
             }
-            catch (Exception exception)
+            catch (Exception e)
             {
-                MessageBox.Show(this, $"Error: {exception}", "BlockTheSpot", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                MessageBox.Show(this, e.StackTrace, "BlockTheSpot", MessageBoxButtons.OK, MessageBoxIcon.Error);
                 WorkingPictureBox.Visible = false;
                 return;
             }
+
+            // Fin de la aplicación...
+
+            SpotifyPictureBox.Image = Properties.Resources.AddsOffImage;
+            WorkingPictureBox.Image = Properties.Resources.DoneImage;
+
+            MessageBox.Show(this, "¡Todo listo! Gracias por utilizar BlockTheSpot.", "BlockTheSpot", MessageBoxButtons.OK, MessageBoxIcon.Information);
+
+            Process.Start($@"{SpotifyDir}\Spotify.exe");
+
+            Application.Exit();
         }
 
         private void ResetButtonMethod()
         {
-            this.Cursor = Cursors.Default;
+            Cursor = Cursors.Default;
             WorkingPictureBox.BringToFront();
             WorkingPictureBox.Visible = true;
 
-            TerminateSpotify();
-
             try
             {
-                ClearSpotify();
-                UpdateSpotify();
-                Finish(false, "¡Spotify ha sido restablecido con éxito!" + Environment.NewLine + "Gracias por utilizar BlockTheSpot.");
+                TerminateSpotify();
+                UndoPatch();
+                UpdateClient();
             }
-            catch (Exception exception)
+            catch (Exception e)
             {
-                MessageBox.Show(this, $"Error: {exception}", "BlockTheSpot", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                MessageBox.Show(this, $"Error: {e.Message}", "BlockTheSpot", MessageBoxButtons.OK, MessageBoxIcon.Error);
                 WorkingPictureBox.Visible = false;
                 return;
             }
-        }
-        #endregion
 
+            SpotifyPictureBox.Image = Properties.Resources.AddsOnImage;
+            WorkingPictureBox.Image = Properties.Resources.DoneImage;
+
+            MessageBox.Show(this, "¡Spotify ha sido restablecido con éxito!\n" + "Gracias por utilizar BlockTheSpot.", "BlockTheSpot", MessageBoxButtons.OK, MessageBoxIcon.Information);
+
+            Application.Exit();
+        }
+        //
+        // *** Excepción esporadica no controlada: <Acceso denegado> ***
         private void TerminateSpotify()
         {
-            foreach (Process process in Process.GetProcessesByName("Spotify")) { process.Kill(); }
-            while (Process.GetProcessesByName("Spotify").Length > 0) Thread.Sleep(100);
-        }
-
-        #region Patch Methods
-        private void SpotifyDowngrade()
-        {
-            if (DowngradeRequired())
+            foreach (Process p in Process.GetProcessesByName("Spotify"))
             {
-                try
-                {
-                    using (WebClient client = new WebClient()) { client.DownloadFile("http://upgrade.spotify.com/upgrade/client/win32-x86/spotify_installer-1.1.4.197.g92d52c4f-13.exe", $"{Path.GetTempPath()}spotify_installer-1.1.4.197.g92d52c4f-13.exe"); }
-                }
-                catch (WebException)
-                {
-                    throw new Exception("No ha sido posible descargar los archivos necesarios." + Environment.NewLine + "Comprueba tu conexión a internet e inténtalo de nuevo.");
-                }
-
-                if (File.Exists($@"{SpotifyDir}\Spotify.exe"))
-                {
-                    PowerShell.Create().AddScript($"cmd /C \"`\"{Path.GetTempPath()}spotify_installer-1.1.4.197.g92d52c4f-13.exe`\" /extract \"\"{SpotifyDir}\"").Invoke();
-                }
-
-                if (DowngradeRequired())
-                {
-                    Process.Start($"{Path.GetTempPath()}spotify_installer-1.1.4.197.g92d52c4f-13.exe").WaitForExit();
-
-                    try { File.Delete($"{Path.GetTempPath()}spotify_installer-1.1.4.197.g92d52c4f-13.exe"); } catch (Exception) { }  // Conflict
-
-                    TerminateSpotify();
-                }
+                p.Kill();
+                p.WaitForExit();
             }
         }
+        //
+        // Intenta desinstalar el paquete UWP <SpotifyAB.SpotifyMusic>, incompatible con BlockTheSpot.
+        private void WinStorePackageRemoval()
+        {
+            var pkgManager = new Windows.Management.Deployment.PackageManager();
+            var spotifyPkg = pkgManager.FindPackagesForUser(string.Empty).FirstOrDefault(pkg => pkg.Id.Name.Equals("SpotifyAB.SpotifyMusic"));
 
-        private void InjectNatutils()
+            // El paquete <SpotifyAB.SpotifyMusic> no esta instalado en la cuenta usuario actual.
+            if (spotifyPkg == null)
+                return;
+
+            // Desinstala el paquete <SpotifyAB.SpotifyMusic> de la cuenta usuario actual.
+            var removal = pkgManager.RemovePackageAsync(spotifyPkg.Id.FullName); /// RemovalOptions.RemoveForAllUsers
+
+            // Este evento es señalado cunado la operación finaliza.
+            ManualResetEvent removalEvent = new ManualResetEvent(false);
+
+            // Define el delago con un argumento lambda.
+            removal.Completed = (depProgress, status) => { removalEvent.Set(); };
+
+            // Espera a que la operación finalice.
+            removalEvent.WaitOne();
+
+            if (removal.Status != Windows.Foundation.AsyncStatus.Completed)
+                throw new Exception("La desintalación del paquete SpotifyAB.SpotifyMusic (Microsoft Store) ha fallado:\n" + removal.GetResults().ErrorText + "\n\nPara evitar conflictos, es necesario desinstalar este paquete. Prueba a ejecutar BlockTheSpot como administrador o realiza la desinstalación manualmente.");
+        }
+
+        private void DowngradeClient()
+        {
+            if (!DowngradeRequired())
+                return;
+
+            try
+            {
+                // Desbloquea el control total de la carpeta de actualizaciones para el grupo de usuarios actual y,
+                // evitar así una excepción en el método siguiente <DeleteAllFilesExcept()>.
+                FileSecurity($@"{SpotifyLocalDir}\Update", FileSystemRights.FullControl, AccessControlType.Allow, true);
+
+                // Elimina todos los archivos de los directorios de Spotify,
+                // exceptuando los archivos propios del perfil de usuario.
+                DeleteAllFilesExcept(SpotifyDir, new List<string>() { "Users" }, new List<string> { "prefs" });
+                DeleteAllFilesExcept(SpotifyLocalDir, new List<string>() { "Users", "Cache", "Cache_Data", "Code_Cache", "GPUCache" },
+                    new List<string> { "LocalPrefs.json" });
+
+                string fileName = "spotify_installer-1.1.89.862.g94554d24-13.exe";
+
+                new WebClient().DownloadFile(SpotifyUri, Path.GetTempPath() + fileName);
+
+                // Inicia el instalador de la última versión de Spotify compatible con BlockTheSpot (1.1.89.862).
+                TopMost = false;
+                Process.Start(Path.GetTempPath() + fileName).WaitForExit();
+                TopMost = true;
+
+                TerminateSpotify();
+            }
+            catch (WebException)
+            {
+                throw new Exception("No ha sido posible descargar los archivos necesarios.\n" + "Comprueba tu conexión a internet e inténtalo de nuevo.");
+            }
+            catch (Exception)
+            {
+                // No controlar.
+            }
+
+
+            // Comprueba si la instalación ha sido completada con éxito.
+            if (DowngradeRequired())
+                throw new Exception($"El downgrade de Spotify ha fallado.");
+        }
+
+        private void Patch()
         {
             try
             {
-                using (WebClient client = new WebClient()) { client.DownloadFile("https://raw.githubusercontent.com/master131/BlockTheSpot/master/netutils.dll", $"{Path.GetTempPath()}netutils.dll"); }
+                // Descarga los archivos encargados de bloquear los anuncios de Spotify.
+                string fileName = "chrome_elf.zip";
+                new WebClient().DownloadFile(ChromeElfUri, Path.GetTempPath() + fileName);
 
-                if (File.Exists($"{Path.GetTempPath()}netutils.dll"))
-                {
-                    File.Copy($"{Path.GetTempPath()}netutils.dll", $@"{SpotifyDir}\netutils.dll", true);
-                    File.Delete($"{Path.GetTempPath()}netutils.dll");
-                }
+                // Elimina el directorio destino de descompresión, si existiera.
+                if (Directory.Exists(Path.GetTempPath() + "chrome_elf\\"))
+                    Directory.Delete(Path.GetTempPath() + "chrome_elf\\", true);
 
-                if (File.Exists($@"{SpotifyDir}\SpotifyMigrator.exe"))
-                    File.Delete($@"{SpotifyDir}\SpotifyMigrator.exe");
+                // Extrae los archivos <chrome_elf.dll> y <config.ini> del archivo zip descargado.
+                System.IO.Compression.ZipFile.ExtractToDirectory(Path.GetTempPath() + fileName, Path.GetTempPath() + "chrome_elf\\");
 
-                if (File.Exists($@"{SpotifyDir}\SpotifyStartupTask.exe"))
-                    File.Delete($@"{SpotifyDir}\SpotifyStartupTask.exe");
+                // Introduce los archivos en el directorio principal de Spotify y crea un respaldo del archivo <chrome_elf.dll>.
+                // * Debe existir previamente el archivo <chrome_elf.dll> para poder llevar a cabo el parche.
+                File.Replace($@"{Path.GetTempPath()}chrome_elf\chrome_elf.dll", $@"{SpotifyDir}\chrome_elf.dll", $@"{SpotifyDir}\chrome_elf_bak.dll");
+                File.Copy($@"{Path.GetTempPath()}chrome_elf\config.ini", $@"{SpotifyDir}\config.ini", true);
             }
             catch (WebException)
             {
@@ -184,95 +239,120 @@ namespace BlockTheSpot
 
         private void DisableAutoUpdate()
         {
-            if (Directory.Exists(UpdateFolderDir))
-            {
-                FileSecurity(UpdateFolderDir, FileSystemRights.FullControl, AccessControlType.Allow, true);
-                Directory.Delete(UpdateFolderDir, true);
-            }
-            Directory.CreateDirectory(UpdateFolderDir);
-            FileSecurity(UpdateFolderDir, FileSystemRights.FullControl, AccessControlType.Deny, true);
-        }
-        #endregion
-
-        #region Reset Methods
-        private void ClearSpotify()
-        {
             try
             {
-                FileSecurity(UpdateFolderDir, FileSystemRights.FullControl, AccessControlType.Allow, true);
+                if (Directory.Exists($@"{SpotifyLocalDir}\Update"))
+                {
+                    // Elimina la carpeta de actualizaciones de Spotify.
+                    FileSecurity($@"{SpotifyLocalDir}\Update", FileSystemRights.FullControl, AccessControlType.Allow, true);
+                    Directory.Delete($@"{SpotifyLocalDir}\Update", true);
+                }
 
-                if (Directory.Exists(UpdateFolderDir))
-                    Directory.Delete(UpdateFolderDir, true);
-
-                if (File.Exists($@"{SpotifyDir}\netutils.dll"))
-                    File.Delete($@"{SpotifyDir}\netutils.dll");
+                // Bloquea el control total de la carpeta de actualizaciones para el grupo de usuarios actual.
+                Directory.CreateDirectory($@"{SpotifyLocalDir}\Update");
+                FileSecurity($@"{SpotifyLocalDir}\Update", FileSystemRights.FullControl, AccessControlType.Deny, true);
             }
             catch (UnauthorizedAccessException)
             {
-                throw new UnauthorizedAccessException($"Los permisos de acceso a los directorios, mencionados a continuación, han sido restringidos utilizando privilegios de Administrador, eliminelos y vuelva a intentarlo: \"{SpotifyDir}\\netutils.dll\" \"{UpdateFolderDir}\\\"");
+                throw new UnauthorizedAccessException($"No ha sido posible acceder a la siguiente ruta: \"{SpotifyLocalDir}\\Update\\\"." + Environment.NewLine + Environment.NewLine + "Prueba a ejecutar BlockTheSpot como Administrador.");
             }
         }
 
-        private void UpdateSpotify()
+        private void UndoPatch()
         {
             try
             {
-                using (WebClient client = new WebClient()) { client.DownloadFile("https://download.scdn.co/SpotifySetup.exe", $"{Path.GetTempPath()}spotify_installer-update.exe"); }
+                // Desbloquea el control total de la carpeta de actualizaciones para el grupo de usuarios actual.
+                FileSecurity($@"{SpotifyLocalDir}\Update", FileSystemRights.FullControl, AccessControlType.Allow, true);
 
-                Process.Start($"{Path.GetTempPath()}spotify_installer-update.exe").WaitForExit();
+                // Elimina el archivo parcheado <chrome_elf.dll>.
+                if (File.Exists($@"{SpotifyDir}\chrome_elf.dll"))
+                    File.Delete($@"{SpotifyDir}\chrome_elf.dll");
 
-                try { File.Delete($"{Path.GetTempPath()}spotify_installer-update.exe"); } catch (Exception) { }  // Conflict
+                // Restaura el archivo original desde <chrome_elf_bak.dll>.
+                if (File.Exists($@"{SpotifyDir}\chrome_elf_bak.dll"))
+                    File.Move($@"{SpotifyDir}\chrome_elf_bak.dll", $@"{SpotifyDir}\chrome_elf.dll");
+
+                // Elimina el archivo <config.ini>. El archivo <chrome_elf.dll> se rescribirá al actualizar Spotify.
+                if (File.Exists($@"{SpotifyDir}\config.ini"))
+                    File.Delete($@"{SpotifyDir}\config.ini");
+            }
+            catch (UnauthorizedAccessException)
+            {
+                throw new UnauthorizedAccessException($"No ha sido posible acceder a la siguiente ruta: \"{SpotifyLocalDir}\\Update\\\"." + Environment.NewLine + Environment.NewLine + "Prueba a ejecutar BlockTheSpot como Administrador.");
+            }
+        }
+
+        private void UpdateClient()
+        {
+            try
+            {
+                string fileName = "spotify_installer-update.exe";
+                new WebClient().DownloadFile("https://download.scdn.co/SpotifySetup.exe", Path.GetTempPath() + fileName);
+
+                // Inicia el instalador de la ultima versión de Spotify.
+                TopMost = false;
+                Process.Start(Path.GetTempPath() + fileName).WaitForExit();
+                TopMost = true;
             }
             catch (WebException)
             {
-                MessageBox.Show(this, "No ha sido posible actualizar Spotify a su última versión." + Environment.NewLine + "Puede llevar a cabo facilmente esta actualización accediendo al apartado de [Configuración], [Acerca de Spotify] directamente desde los ajustes de Spotify.", "BlockTheSpot", MessageBoxButtons.OK, MessageBoxIcon.Exclamation);
+                MessageBox.Show(this, "No ha sido posible actualizar Spotify a su última versión." + Environment.NewLine + "Puedes llevar a cabo facilmente esta actualización accediendo al apartado de [Configuración], [Acerca de Spotify] desde los ajustes de Spotify.", "BlockTheSpot", MessageBoxButtons.OK, MessageBoxIcon.Exclamation);
             }
         }
-        #endregion
 
-        private void Finish(bool patch, string message)
+        private void FileSecurity(string dir, FileSystemRights rights, AccessControlType controlType, bool addRule)
         {
-            if (patch)
-                SpotifyPictureBox.Image = Properties.Resources.AddsOffImage;
-            else
-                SpotifyPictureBox.Image = Properties.Resources.AddsOnImage;
-
-            WorkingPictureBox.Image = Properties.Resources.DoneImage;
-
-            this.TopMost = true; MessageBox.Show(this, message, "BlockTheSpot", MessageBoxButtons.OK, MessageBoxIcon.Information);
-
-            if (patch)
-                Process.Start($@"{SpotifyDir}\Spotify.exe");
-
-            Application.Exit();
-        }
-
-        private void FileSecurity(string dirPath, FileSystemRights rights, AccessControlType controlType, bool addRule)
-        {
-            if (Directory.Exists(dirPath))
+            if (Directory.Exists(dir))
             {
-                DirectorySecurity fSecurity = Directory.GetAccessControl(dirPath);
-                fSecurity.SetAccessRuleProtection(false, false);
-                AuthorizationRuleCollection rules = fSecurity.GetAccessRules(true, true, typeof(NTAccount));
-                foreach (FileSystemAccessRule rule in rules) fSecurity.RemoveAccessRule(rule);
+                DirectorySecurity dirSecurity = Directory.GetAccessControl(dir);
+
+                dirSecurity.SetAccessRuleProtection(false, false);
+
+                foreach (FileSystemAccessRule rule in dirSecurity.GetAccessRules(true, true, typeof(NTAccount)))
+                    dirSecurity.RemoveAccessRule(rule);
 
                 if (addRule)
-                    fSecurity.AddAccessRule(new FileSystemAccessRule(WindowsIdentity.GetCurrent().Name, rights, controlType));
+                    dirSecurity.AddAccessRule(new FileSystemAccessRule(WindowsIdentity.GetCurrent().Name, rights, controlType));
                 else
-                    fSecurity.RemoveAccessRule(new FileSystemAccessRule(WindowsIdentity.GetCurrent().Name, rights, controlType));
+                    dirSecurity.RemoveAccessRule(new FileSystemAccessRule(WindowsIdentity.GetCurrent().Name, rights, controlType));
 
-                Directory.SetAccessControl(dirPath, fSecurity);
+                Directory.SetAccessControl(dir, dirSecurity);
             }
         }
 
+        private void DeleteAllFilesExcept(string targetDir, List<string> dirNamesToSkip, List<string> fileNamesToSkip)
+        {
+            List<string> availableDirs = new List<string>() { targetDir };
+            List<string> availableFiles = new List<string>();
+
+            availableDirs.AddRange(Directory.EnumerateDirectories(targetDir, "*",
+                SearchOption.AllDirectories).Where(s =>
+                !dirNamesToSkip.Any(d => s.Contains("Spotify\\" + d))).ToList());
+
+            foreach (string dir in availableDirs)
+                availableFiles.AddRange(Directory.EnumerateFiles(dir).Where(s =>
+                !fileNamesToSkip.Any(f => s.Contains("Spotify\\" + f))).ToList());
+
+            foreach (string path in availableFiles)
+                File.Delete(path);
+        }
+
+
+        private void PatchButton_Click(object sender, EventArgs args) => PatchButtonMethod();
+        private void ResetButton_Click(object sender, EventArgs args) => ResetButtonMethod();
+        private void BlockTheSpot_HelpButtonClicked(object sender, EventArgs args) => Process.Start("https://github.com/bitasuperactive/BlockTheSpot-C-Sharp");
+        //
+        // Si el usuario trata de cerrar BlockTheSpot mientras se encuentra en medio de la ejecución,
+        // confirmar la solicitud de cierre.
         private void BlockTheSpot_FormClosing(object sender, FormClosingEventArgs close)
         {
             if (close.CloseReason == CloseReason.UserClosing && WorkingPictureBox.Visible)
             {
-                DialogResult exitMessage = MessageBox.Show(this, "BlockTheSpot no ha terminado su trabajo, ¿deseas cerrar la aplicación de todas formas?", "BlockTheSpot", MessageBoxButtons.YesNo, MessageBoxIcon.Exclamation);
+                DialogResult exitMessage = MessageBox.Show(this, "BlockTheSpot no ha terminado su trabajo, ¿Deseas cerrar la aplicación de todas formas?", "BlockTheSpot", MessageBoxButtons.YesNo, MessageBoxIcon.Exclamation);
+                
                 if (exitMessage == DialogResult.No)
                     close.Cancel = true;
-                // Pause threads?
             }
         }
     }

--- a/BlockTheSpot/Properties/AssemblyInfo.cs
+++ b/BlockTheSpot/Properties/AssemblyInfo.cs
@@ -33,6 +33,6 @@ using System.Runtime.InteropServices;
 // Puede especificar todos los valores o usar los valores predeterminados de número de compilación y de revisión
 // utilizando el carácter "*", como se muestra a continuación:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.3.0.0")]
-[assembly: AssemblyFileVersion("1.3.0.0")]
+[assembly: AssemblyVersion("2.0.0.0")]
+[assembly: AssemblyFileVersion("2.0.0.0")]
 [assembly: NeutralResourcesLanguage("es-ES")]


### PR DESCRIPTION
## BlockTheSpot v2.0

- **Metodología de parcheo actualizada** para la versión de cliente *1.1.89.862.g94554d24-13* (funcional).
*Basado en: https://github.com/mrpond/BlockTheSpot*
- **WinStorePackageRemoval**
Intenta desinstalar automáticamente el paquete UWP <SpotifyAB.SpotifyMusic> para el grupo de usuarios actual, pues es incompatible con la metología de parcheo de BlockTheSpot.
- **DeleteAllFilesExcept()**
Elimina todos los archivos relativos a la versión de escritorio de Spotify, si la hubiera instalada, a excepción de los archivos propios de la configuración y caché del usuario.
- Métodos renombrados y reorganizados para mayor claridad.
- Comentarios añadidos.

Problemas conocidos:
1. Excepción no controlada al tratar de cerrar Spotify desde el código, previa ejecución del parcheo.